### PR TITLE
Add VARNISH_PORT back to readme

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - "README.md"
 
 jobs:
   build-push-varnish:

--- a/README.md
+++ b/README.md
@@ -11,17 +11,20 @@ The following environment settings are expected:
 * `S3_VCL_FILE` - The location of a vcl file to use. Expected S3Uri as it is used by [aws s3 cp](https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html) command.
 * `VARNISH_CACHE_FOLDER` - Folder where disk backed cache is stored.
 * `VARNISH_CACHE_SIZE` - Size of cache.
-* `AWS_PROFILE` - Required to run locally
 
 The following configuration is optional:
 
 * `VARNISH_CACHE_FILE` - The name of varnish [storage file](https://varnish-cache.org/docs/trunk/users-guide/storage-backends.html#file) (e.g. `varnish_cache.bin`). If specified it is appended to `VARNISH_CACHE_FOLDER` to create file (if unspecified folder only is used)
 * `INCOMING_QUEUE` - the name of the queue that the cleanup handler listens to
 * `VARNISH_ADDRESS` - The location of varnish used by the cleanup handler. Defaults to localhost
+* `AWS_PROFILE` - Required to run locally
 * `AWS_REGION` - The AWS region. Defaults to eu-west-1
-* `USE_LOCAL_CONFIG` - Whether to use a local config file over S3. 
+* `USE_LOCAL_CONFIG` - Whether to use a local config file over S3.
+* `VARNISH_PORT` - Which port Varnish should listen on. Defaults to 80
 
-*NOTE:* using `USE_LOCAL_CONFIG` requires a `mount`to be added to the `docker run` containing the VCL
+> [!NOTE]
+> Using `USE_LOCAL_CONFIG` requires a `mount` to be added to the `docker run` containing the VCL
+
 ## Running
 
 ```bash
@@ -44,10 +47,8 @@ Additionally, there is a standalone docker container for the cleanup handler.
 
 ### Configuration
 
-Required:
-* `AWS_PROFILE` - Required to run locally
-
 Optional:
+* `AWS_PROFILE` - Required to run locally
 * `VARNISH_ADDRESS` - The location of varnish used by the cleanup handler. Defaults to localhost
 * `AWS_REGION` - The region used by the cleanup handler. Defaults to eu-west-1
 


### PR DESCRIPTION
Main change was adding `VARNISH_PORT` back to list of optional envvars, this was deleted in error when readme was updated in #5.

Also moved `AWS_PROFILE` to "optional" section to clarify that it isn't required for normal running.